### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ You can find a ripple effect applied on a button in [AppCorner Social](https://g
 ![Alt text](/preview.png "Preview") 
 ![Alt text](/preview_ios7.png "Preview iOS 7") 
 
-##No longer maintained but still working.
+## No longer maintained but still working.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
